### PR TITLE
make search on titles case insesitive

### DIFF
--- a/src/filterEmoji.js
+++ b/src/filterEmoji.js
@@ -2,7 +2,7 @@ import emojiList from './emojiList.json';
 
 export default function filterEmoji(searchText, maxResults) {
   return emojiList.filter((emoji) => {
-    if (emoji.title.includes(searchText)) {
+    if (emoji.title.toLowerCase().includes(searchText.toLowerCase())) {
       return true;
     }
     if (emoji.keywords.includes(searchText)) {


### PR DESCRIPTION
This fixes an issue that prevented me to get results while searching for `poop`.

Such a bummer 💩💩💩💩