### PR TITLE
Use emoji title as key

### DIFF
--- a/src/EmojiResults.js
+++ b/src/EmojiResults.js
@@ -12,7 +12,7 @@ class EmojiResults extends React.Component {
           this.props.emojiData.map((emojiData) => {
             return (
               <EmojiResultRow
-                key={emojiData.symbol}
+                key={emojiData.title}
                 symbol={emojiData.symbol}
                 title={emojiData.title}
               />


### PR DESCRIPTION
When I increased the number of filtered items to show I noticed skin tones produce duplicate keys.
This fixes it (I assume titles *are* unique).