### PR TITLE
Component name same as file name EmojiResultRow.js

### DIFF
--- a/src/EmojiResultRow.js
+++ b/src/EmojiResultRow.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import "./EmojiResultRow.css";
 
-export default class EmojiResultsRow extends PureComponent {
+export default class EmojiResultRow extends PureComponent {
   static propTypes = {
     title: PropTypes.string,
     symbol: PropTypes.string


### PR DESCRIPTION
remove letter 's' in order to name component same as file name
`EmojiResultRow` instead of `EmojiResult**s**Row`